### PR TITLE
Incomplete reads

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,5 +30,5 @@ jobs:
         flake8 . --count --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pip install pytest flask
+        pip install pytest
         pytest

--- a/ipfsspec/core.py
+++ b/ipfsspec/core.py
@@ -113,6 +113,8 @@ class IPFSFileSystem(AbstractFileSystem):
                 backoff_list.append((wait_time, gw))
         if len(backoff_list) > 0:
             return sorted(backoff_list)[0][::-1]
+        else:
+            raise RuntimeError("no working gateways could be found")
 
     def _run_on_any_gateway(self, f):
         timeout = time.monotonic() + self.timeout

--- a/ipfsspec/core.py
+++ b/ipfsspec/core.py
@@ -31,6 +31,7 @@ class IPFSGateway:
             if actual_length < expected_length:
                 # if less than the expected amount of data is delivered, just backoff which will will eiter trigger a
                 # retry on the same server or will fall back to another server later on.
+                logger.debug("received size of resource %s is %d, but %d was expected", path, actual_length, expected_length)
                 self._backoff()
                 return None
 

--- a/ipfsspec/core.py
+++ b/ipfsspec/core.py
@@ -23,6 +23,17 @@ class IPFSGateway:
 
     def get(self, path):
         res = self.session.get(self.url + "/ipfs/" + path)
+        # this is from https://blog.petrzemek.net/2018/04/22/on-incomplete-http-reads-and-the-requests-library-in-python/
+        expected_length = res.headers.get('Content-Length')
+        if expected_length is not None:
+            actual_length = res.raw.tell()
+            expected_length = int(expected_length)
+            if actual_length < expected_length:
+                # if less than the expected amount of data is delivered, just backoff which will will eiter trigger a
+                # retry on the same server or will fall back to another server later on.
+                self._backoff()
+                return None
+
         if res.status_code == 429:  # too many requests
             self._backoff()
             return None

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     ],
     python_requires='>=3',
     install_requires=[
-        "fsspec",
+        "fsspec>=0.8.0",
         "requests",
     ],
 )

--- a/test/mockserver.py
+++ b/test/mockserver.py
@@ -1,76 +1,39 @@
-import requests
-import pytest
+import http.server
+from contextlib import contextmanager
 
-from flask import Flask, jsonify
-from threading import Thread
-from uuid import uuid4
-
-if False:
-    import click
-    import logging
-    log = logging.getLogger('werkzeug')
-    log.setLevel(logging.ERROR)
-    log.disabled = True
-
-    def secho(text, file=None, nl=None, err=None, color=None, **styles):
-        pass
-
-    def echo(text, file=None, nl=None, err=None, color=None, **styles):
-        pass
-
-    click.echo = echo
-    click.secho = secho
+import threading
+import random
 
 
-class MockServer(Thread):
-    def __init__(self, port=5000):
-        super().__init__()
-        self.port = port
-        self.app = Flask(__name__)
-        self.app.logger.disabled = True
-        self.url = "http://localhost:%s" % self.port
-
-        self.app.add_url_rule("/shutdown", view_func=self._shutdown_server)
-
-    def _shutdown_server(self):
-        from flask import request
-        if 'werkzeug.server.shutdown' not in request.environ:
-            raise RuntimeError('Not running the development server')
-        request.environ['werkzeug.server.shutdown']()
-        return 'Server shutting down...'
-
-    def shutdown_server(self):
-        requests.get("http://localhost:%s/shutdown" % self.port)
-        self.join()
-
-    def add_callback_response(self, url, callback, methods=('GET',)):
-        callback.__name__ = str(uuid4())  # change name of method to mitigate flask exception
-        self.app.add_url_rule(url, view_func=callback, methods=methods)
-
-    def add_json_response(self, url, serializable, methods=('GET',)):
-        def callback():
-            return jsonify(serializable)
-
-        self.add_callback_response(url, callback, methods=methods)
-
-    def run(self):
-        self.app.run(port=self.port)
+def is_port_in_use(port):
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex(('localhost', port)) == 0
 
 
-@pytest.fixture
-def mock_server():
-    server = MockServer()
-    server.start()
-    yield server
-    server.shutdown_server()
+def any_free_port():
+    port = random.randint(4001, 7999)
+    while is_port_in_use(port):
+        port = random.randint(4001, 7999)
+    return port
 
 
-@pytest.fixture
-def dual_mock_server():
-    server1 = MockServer(5000)
-    server2 = MockServer(5001)
-    server1.start()
-    server2.start()
-    yield server1, server2
-    server1.shutdown_server()
-    server2.shutdown_server()
+@contextmanager
+def mock_servers(handlers):
+    servers = []
+    urls = []
+    threads = []
+    for handler in handlers:
+        port = any_free_port()
+        server = http.server.HTTPServer(("localhost", port), handler)
+        url = "http://localhost:%s" % port
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        servers.append(server)
+        urls.append(url)
+        threads.append(thread)
+    yield urls
+    for server in servers:
+        server.shutdown()
+    for thread in threads:
+        thread.join()

--- a/test/test_gateway.py
+++ b/test/test_gateway.py
@@ -41,7 +41,7 @@ class BaseIPFSHandler(BaseHTTPRequestHandler):
         query = urllib.parse.parse_qs(urlparts.query)
         if urlparts.path == "/api/v0/object/stat":
             oid = query.get("arg", [])[0]
-            res = {"Hash": oid, "NumLinks": 0, "DataSize": len(self.objects[oid])}
+            res = {"Hash": oid, "NumLinks": 0, "DataSize": self.object_size(oid)}
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.end_headers()


### PR DESCRIPTION
This PR fixes two issues due to incomplete file reads:
* In some cases, requests can return incomplete HTTP response data without any warnings. If the server provides the Content-Length header, the failure is detected and the request will be rescheduled, possibly towards a different gateway
* fsspec prior to 0.8.0 sometimes returns incomplete file contents, so fsspec >= 0.8.0 is now required via setup.py