### PR TITLE
register filesystem via entry_points

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A readonly implementation of fsspec for IPFS.
 This project is currently very rudimentaty. It is not yet optimized for efficiency and is not yet feature complete. However it should be enough to list directory contents and to retrieve files from `ipfs://` resources via fsspec. A simple hello worlds would look like:
 
 ```python
-import ipfsspec  # this is needed to register the protocol with fsspec
 import fsspec
 
 with fsspec.open("ipfs://QmZ4tDuvesekSs4qM5ZBKpXiZGun7S2CYtEZRB3DYXkjGx", "r") as f:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     ],
     python_requires='>=3',
     install_requires=[
-        "fsspec>=0.8.0",
+        "fsspec>=0.9.0",
         "requests",
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,9 @@ setuptools.setup(
         "fsspec>=0.8.0",
         "requests",
     ],
+    entry_points={
+        'fsspec.specs': [
+            'ipfs=ipfsspec.IPFSFileSystem',
+        ],
+    },
 )

--- a/test/test_gateway.py
+++ b/test/test_gateway.py
@@ -2,7 +2,6 @@ import datetime
 import json
 from mockserver import mock_servers
 
-import ipfsspec  # noqa: F401
 import fsspec
 
 from http.server import BaseHTTPRequestHandler

--- a/test/test_ipfs.py
+++ b/test/test_ipfs.py
@@ -1,4 +1,3 @@
-import ipfsspec  # noqa: F401
 import fsspec
 
 


### PR DESCRIPTION
This feature is not yet documented in fsspec. I am not sure if this is
used correctly and will stay like this in the future.

This PR should be merged after intake/filesystem_spec#548 is resolved.